### PR TITLE
Minor build fixups

### DIFF
--- a/mcrouter/scripts/Makefile_amazon-linux-2
+++ b/mcrouter/scripts/Makefile_amazon-linux-2
@@ -69,4 +69,4 @@ mcrouter: .fbthrift-done .folly-done .fizz-done .wangle-done .fmt-done .zstd-don
 
 archive: mcrouter
 	touch $@
-	tar czfv "mcrouter.$$(git rev-parse --short=12 HEAD).$$(uname -m).tar.gz" -C $(INSTALL_DIR) .
+	tar czfv "mcrouter.$$(git rev-parse --short=12 HEAD).$$(uname -m).tar.gz" -C $(INSTALL_DIR) aux bin lib lib64 share

--- a/mcrouter/scripts/get_and_build_by_make.sh
+++ b/mcrouter/scripts/get_and_build_by_make.sh
@@ -28,7 +28,7 @@ mkdir -p "$INSTALL_DIR/lib"
 # As a workaround, we just upfront link lib64 -> lib so all dependency artifacts
 # end up in $INSTALL_DIR/lib which that build script *can* find.
 if [ ! -e "$INSTALL_DIR/lib64" ]; then
-    ln -sf "$INSTALL_DIR/lib" "$INSTALL_DIR/lib64"
+    ln -sf lib "$INSTALL_DIR/lib64"
 fi
 
 cd "$(dirname "$0")" || ( echo "cd fail"; exit 1 )


### PR DESCRIPTION
### Use relative path in symlink

Specifying the absolute path as the target to the symlink causes
portability problems because when we eventually archive up the result
for distribution, the absolute paths will be incorrect on the target
systems.

### Exclude "include/" distributable archive.

We are really only packaging the runtime dependencies, we do not need
the development headers.

This saves ~200mb on the target systems.

[Clubhouse Story 157106](https://app.clubhouse.io/internal/story/157106)

Risk is low
