### PR TITLE
[mcrouter] adjust tarball construction

### DIFF
--- a/mcrouter/scripts/slim-archive.sh
+++ b/mcrouter/scripts/slim-archive.sh
@@ -29,4 +29,4 @@ LD_LIBRARY_PATH="${INSTALL_DIR}"/lib ldd "${INSTALL_DIR}"/bin/mcrouter "${INSTAL
     | xargs -I '%' cp '%' "${ARCHIVE_INSTALL_DIR}"/lib
 cp "${INSTALL_DIR}"/bin/mcrouter "${INSTALL_DIR}"/bin/mcpiper "${ARCHIVE_INSTALL_DIR}"/bin/
 
-tar czfv "${ARCHIVE}" -C "${ARCHIVE_INSTALL_DIR}" .
+tar czfv "${ARCHIVE}" -C "${ARCHIVE_INSTALL_DIR}" bin lib


### PR DESCRIPTION
`tar cf "ARCHIVE_FILE" .` has a strange side effect that it includes a
reference to the current dir (which given the syntax, isn't unexpected I
guess), but in practice that mangles the paths in the archive to prefix
them all with "./" and confounds the permissions on the target directory
when you extract the archive.

[Clubhouse Story pgroudas/fix-tarball](https://app.clubhouse.io/internal/story/pgroudas/fix-tarball)

Risk is low
